### PR TITLE
Added Github Highlights for fennel files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.fnl linguist-language=Clojure
+*.fnl linguist-vendored


### PR DESCRIPTION
- Extends Clojore's highlights on *.fnl.
- taken from [@ggandor/lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim) 