### PR TITLE
Correct macro gensym usage

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # it's just a handful of files, so
 


### PR DESCRIPTION
Zest as it stands is referring to gensym symbols (`LIKE_THIS#`) across syntax quote boundaries. This works in older versions of Fennel but is actually incorrect! This is essentially relying on a bug in the Fennel compiler which has since been fixed, using the same looking gensym in two different syntax quotes _should_ generate two symbols.

If you want to use a symbol _across_ syntax quote boundaries you need to call `(gensym ...)` yourself and capture the result then unquote that into the code wherever you need it.

I've done this for all macros that use gensym across boundaries, hopefully this works well for you, I've only tried it against a minimal block of code. You can prove this is an issue by updating your Fennel compiler and seeing Zest generate invalid symbols that don't line up.